### PR TITLE
Satisfy Github's Syntax Highlighting

### DIFF
--- a/boilerplates/convert/src/screens/VideoSelectScreen.js
+++ b/boilerplates/convert/src/screens/VideoSelectScreen.js
@@ -17,7 +17,7 @@ class VideoSelectScreen extends Component {
 
     if (videos.length) {
       this.props.addVideos(videos);
-      
+
       if (!this.props.small) {
         this.props.history.push('/convert');
       }
@@ -29,7 +29,7 @@ class VideoSelectScreen extends Component {
     if (isDragActive) {
       return <h4 className="drop-message">Omnomnom, let me have those videos!</h4>;
     } else if (isDragReject) {
-      return <h4 className="drop-message">Uh oh, I don't know how to deal with that type of file!</h4>;
+      return <h4 className="drop-message">{'Uh oh, I don\'t know how to deal with that type of file!'}</h4>;
     } else {
       return <h4 className="drop-message">Drag and drop some files on me, or click to select.</h4>
     }

--- a/completed_code/convert/src/screens/VideoSelectScreen.js
+++ b/completed_code/convert/src/screens/VideoSelectScreen.js
@@ -17,7 +17,7 @@ class VideoSelectScreen extends Component {
 
     if (videos.length) {
       this.props.addVideos(videos);
-      
+
       if (!this.props.small) {
         this.props.history.push('/convert');
       }
@@ -29,7 +29,7 @@ class VideoSelectScreen extends Component {
     if (isDragActive) {
       return <h4 className="drop-message">Omnomnom, let me have those videos!</h4>;
     } else if (isDragReject) {
-      return <h4 className="drop-message">Uh oh, I don't know how to deal with that type of file!</h4>;
+      return <h4 className="drop-message">{'Uh oh, I don\'t know how to deal with that type of file!'}</h4>;
     } else {
       return <h4 className="drop-message">Drag and drop some files on me, or click to select.</h4>
     }


### PR DESCRIPTION
Tiny fix that makes the ugly, red, linter like highlighting go away when viewing the VideoSelectScreen.js files on Github 💁 This could've been fixed by using different grammar for the drop message but I figured not everyone taking this course is familiar with jsx so they might learn a new trick from this.