### PR TITLE
Updates the electron version in packages.json of tasky

### DIFF
--- a/boilerplates/tasky/package.json
+++ b/boilerplates/tasky/package.json
@@ -9,7 +9,7 @@
   },
   "author": "Rallycoding",
   "devDependencies": {
-    "electron": "~1.6.2"
+    "electron": "~5.0.2"
   },
   "dependencies": {
     "babel-core": "^6.24.0",


### PR DESCRIPTION
Updates the electron version. Tray icon works fine on Ubuntu os. Fixes #9 