### PR TITLE
Fix bug with convertVideos function in actions/index.js

### DIFF
--- a/boilerplates/convert/src/components/ConvertPanel.js
+++ b/boilerplates/convert/src/components/ConvertPanel.js
@@ -1,29 +1,36 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
-import * as actions from '../actions';
+import * as actions from '../actions'
+import _ from 'lodash'
 
 class ConvertPanel extends Component {
-
   onCancelPressed = () => {
-    this.props.removeAllVideos();
+    this.props.removeAllVideos()
     this.props.history.push('/')
   }
 
   render() {
     return (
-      <div className="convert-panel">
-        <button className="btn red" onClick={this.onCancelPressed}>
+      <div className='convert-panel'>
+        <button className='btn red' onClick={this.onCancelPressed}>
           Cancel
         </button>
-        <button className="btn" onClick={this.props.convertVideos}>
+        <button
+          className='btn'
+          onClick={this.props.convertVideos.bind(null, this.props.videos)}
+        >
           Convert!
         </button>
       </div>
-    );
-  };
+    )
+  }
 }
 
-export default withRouter(
-  connect(null, actions)(ConvertPanel)
-);
+function mapStateToProps(state) {
+  const videos = _.map(state.videos)
+  console.log(`mapStateToProps returned ${videos.length} videos.`)
+  return { videos }
+}
+
+export default withRouter(connect(mapStateToProps, actions)(ConvertPanel))


### PR DESCRIPTION
The ConvertPanel component was not passing in the list of videos to the convertVideos function, breaking the integration with the main process to receive the videoes from React.  Based on some feedback from the Udemy course questions, I added some bindings for the videos object array which is now being passed to the convertVideos function.