### PR TITLE
Changing default for nodeIntegration to True.

### DIFF
--- a/completed_code/videoinfo/index.js
+++ b/completed_code/videoinfo/index.js
@@ -6,7 +6,11 @@ const { app, BrowserWindow, ipcMain } = electron;
 let mainWindow;
 
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({});
+  mainWindow = new BrowserWindow({
+  webPreferences: {
+            nodeIntegration: true
+        }
+  });
   mainWindow.loadURL(`file://${__dirname}/index.html`);
 });
 


### PR DESCRIPTION
This recommendation is the default behavior in Electron since 5.0.0.

It is paramount that you do not enable Node.js integration in any renderer (BrowserWindow, BrowserView, or <webview>) that loads remote content. The goal is to limit the powers you grant to remote content, thus making it dramatically more difficult for an attacker to harm your users should they gain the ability to execute JavaScript on your website.

[From Electron Docs]